### PR TITLE
change nfs::client::mount's parameter $mount to default to the declared ...

### DIFF
--- a/manifests/client/mount.pp
+++ b/manifests/client/mount.pp
@@ -23,7 +23,7 @@ define nfs::client::mount (
   $ensure = 'mounted',
   $server,
   $share,
-  $mount = undef,
+  $mount = $title,
   $remounts = false,
   $atboot = false,
   $options = '_netdev',


### PR DESCRIPTION
...instance's $title

This makes nfs::client::mount defined type more "user friendly" when declaring
NFS mounts explicity instead of gathering exports with a collection.  Eg.

```
nfs::client::mount { '/d1/ftp/Volumes/noaocache':
  ensure  => mounted,
  server  => 'foo.example.org',
  share   => '/export/bar',
}
```
