### PR TITLE
Add Fedora 18+ and Kerberized NFS4 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ to clients.
 
 Optional nfs4-support.
 
+Management of daemons required for Kerberized nfs4
+servers and clients (Red Hat and Fedora only for now).
+
+
 Dependencies
 ----------------------
 
@@ -18,8 +22,11 @@ Clients need to support augeas.
 
 Check Modulesfile for module dependencies
 
-I have tested the module on lucid, precise, centos5 and centos6.
+${original_author} has tested the module on lucid, precise, centos5 and centos6.
 Chances are good it will work on rhel and sles aswell.
+
+18-Jun-2013: Added Fedora 18 support.
+
 
 Examples
 ----------------------
@@ -169,13 +176,18 @@ This will export /data/folder on the server and automagically mount it on client
 
 ### NFSv4 insanely overcomplicated reference example
 
-
 <pre>
 
   # and on individual nodes.
   node server {
     class { 'nfs::server':
-      nfs_v4              => true,
+      nfs_v4                 => true,
+      nfs_v4_kerberos_realm  => 'EXAMPLE.COM',
+      nfs_v4_kerberized      => true,
+      rpcgssd_opts	     => '-v',
+      rpcsvcgssd_opts        => '-v',
+      rpcidmapd_opts         => '-v',
+
       # Below are defaults
       nfs_v4_idmap_domain => $::domain,
       nfs_v4_export_root  => '/export',
@@ -215,6 +227,11 @@ This will export /data/folder on the server and automagically mount it on client
     class { 'nfs::server':
       nfs_v4              => true,
       nfs_v4_idmap_domain => $::domain
+      nfs_v4_kerberos_realm  => 'EXAMPLE.COM',
+      nfs_v4_kerberized      => true,
+      rpcgssd_opts	     => '-v',
+      rpcsvcgssd_opts        => '-v',
+      rpcidmapd_opts         => '-v',
       nfs_v4_mount_root   => '/srv',
     }
 
@@ -241,7 +258,10 @@ This will export /data/folder on the server and automagically mount it on client
 
 Author
 -----------------
-Harald Skoglund <haraldsk@redpill-linpro.com>
+Original by Harald Skoglund <haraldsk@redpill-linpro.com>
+
+Simon Fraser University Research Computing Group
+      (Kerberized NFS4 support; Fedora 18+ support)
 
 Webpage
 -----------------

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -16,13 +16,33 @@
 #  Domain setting for idmapd, must be the same across server
 #  and clients.
 #
+# [nfs_v4_kerberized]
+#  (RHEL only) Toggles SECURE_NFS in /etc/sysconfig/nfs;
+#  enables and runs rpc.gssd and rpc.svgssd
+#
+# [nfs_v4_kerberos_realm]
+#  (RHEL only) For /etc/idmapd.conf's Local-Realms parameter.
 #  Default is to use $::domain fact.
+#
+# [rpcgssd_opts]
+#  (RHEL only) Passes options to rpc.gssd in /etc/sysconfig/nfs.
+#
+# [rpcsvcgssd_opts]
+#  (RHEL only) Passes options to rpc.svcgssd in /etc/sysconfig/nfs.
+#
+# [rpcidmapd_opts]
+#  (RHEL only) Passes options to rpc.idmapd in /etc/sysconfig/nfs.
 #
 # === Examples
 #
 #
 #  class { 'nfs::client':
 #    nfs_v4              => true,
+#    nfs_v4_kerberos_realm  => 'EXAMPLE.COM',
+#    nfs_v4_kerberized      => true,
+#    rpcgssd_opts	    => '-v',
+#    rpcsvcgssd_opts        => '-v',
+#    rpcidmapd_opts         => '-v',
 #    # Generally parameters below have sane defaults.
 #    nfs_v4_mount_root  => "/srv",
 #    nfs_v4_idmap_domain => $::domain,
@@ -39,14 +59,25 @@
 #
 
 class nfs::client (
-  $nfs_v4              = $nfs::params::nfs_v4,
-  $nfs_v4_mount_root   = $nfs::params::nfs_v4_mount_root,
-  $nfs_v4_idmap_domain = $nfs::params::nfs_v4_idmap_domain
+  $nfs_v4                 = $nfs::params::nfs_v4,
+  $nfs_v4_mount_root      = $nfs::params::nfs_v4_mount_root,
+  $nfs_v4_idmap_domain    = $nfs::params::nfs_v4_idmap_domain,
+  $nfs_v4_kerberized      = $nfs::params::nfs_v4_kerberized,
+  $nfs_v4_kerberos_realm  = $nfs::params::nfs_v4_kerberos_realm,  
+  $rpcgssd_opts           = $nfs::params::rpcgssd_opts,
+  $rpcsvcgssd_opts        = $nfs::params::rpcsvcgssd_opts,
+  $rpcidmapd_opts         = $nfs::params::rpcidmapd_opts,
+  
 ) inherits nfs::params {
 
-  class{ "nfs::client::${osfamily}":
-    nfs_v4              => $nfs_v4,
-    nfs_v4_idmap_domain => $nfs_v4_idmap_domain,
+  class{ "nfs::client::${lsbdistid}":
+    nfs_v4                 => $nfs_v4,
+    nfs_v4_idmap_domain    => $nfs_v4_idmap_domain,
+    nfs_v4_kerberized      => $nfs_v4_kerberized,
+    nfs_v4_kerberos_realm  => $nfs_v4_kerberos_realm,
+    rpcgssd_opts           => $rpcgssd_opts,
+    rpcsvcgssd_opts        => $rpcsvcgssd_opts,
+    rpcidmapd_opts         => $rpcidmapd_opts,
   }
 
 }

--- a/manifests/client/fedora.pp
+++ b/manifests/client/fedora.pp
@@ -1,0 +1,20 @@
+# Shamefully stolen from https://github.com/frimik/puppet-nfs
+# refactored a bit
+
+class nfs::client::fedora (
+  $nfs_v4 = false,
+  $nfs_v4_idmap_domain = undef,
+  $nfs_v4_kerberized = false,
+  $nfs_v4_kerberos_realm = undef,
+  $rpcgssd_opts = undef,
+  $rpcsvcgssd_opts = undef,
+  $rpcidmapd_opts = undef,
+  $rpcmountd_opts = undef
+
+  
+) inherits nfs::client::fedora::params {
+
+  include nfs::client::fedora::install, 
+    nfs::client::fedora::configure, 
+    nfs::client::fedora::service
+}

--- a/manifests/client/fedora/configure.pp
+++ b/manifests/client/fedora/configure.pp
@@ -1,0 +1,41 @@
+# Shamefully stolen from https://github.com/frimik/puppet-nfs
+# refactored a bit
+
+class nfs::client::fedora::configure {
+
+  # Because rhel/fedora /etc/sysconfig/nfs doesn't want true/false
+  # it wants yes/no
+  if $nfs::client::fedora::nfs_v4_kerberized {
+     $nfs_v4_secure = 'yes'
+  } else {
+     $nfs_v4_secure = 'no'
+  }
+
+  concat { '/etc/idmapd.conf':
+    warn    => true,
+    mode    => '0644',
+    owner   => 'root',
+    group   => 'root',
+  }
+  concat { '/etc/sysconfig/nfs':
+    warn    => true,
+    mode    => '0644',
+    owner   => 'root',
+    group   => 'root',
+  }
+  concat::fragment { 'idmapd.conf.erb':
+    target  => '/etc/idmapd.conf',
+    order   => 01,
+    content => template('nfs/idmapd.conf.erb'),
+    notify  => Service['nfs-idmap'],
+  }
+
+  # yes, the old /etc/init.d/nfs is called nfs-server now
+  # no, there is no nfs-client on Fedora 17+
+  concat::fragment { 'rhel-sysconfig-nfs':
+    target  => '/etc/sysconfig/nfs',
+    order   => 02,
+    content => template('nfs/rhel-sysconfig-nfs.erb'),
+    notify  => Service['nfs-secure', 'nfs-idmap', 'nfs-server'],
+  }  
+}

--- a/manifests/client/fedora/install.pp
+++ b/manifests/client/fedora/install.pp
@@ -1,0 +1,22 @@
+# Shamefully stolen from https://github.com/frimik/puppet-nfs
+# refactored a bit
+
+class nfs::client::fedora::install {
+
+  Package {
+    before => Class['nfs::client::fedora::configure']
+  }
+  package { 'nfs-utils':
+    ensure => present,
+  }
+  package {'rpcbind':
+      ensure => present,
+  }
+
+  if $nfs::client::fedora::nfs_v4_kerberized {
+    package { ['krb5-libs', 'krb5-workstation', 'krb5-devel',]:
+      ensure => present,
+    }    
+  }
+}
+

--- a/manifests/client/fedora/params.pp
+++ b/manifests/client/fedora/params.pp
@@ -1,0 +1,8 @@
+# Shamefully stolen from https://github.com/frimik/puppet-nfs
+# refactored a bit
+
+class nfs::client::fedora::params {
+
+}
+
+

--- a/manifests/client/fedora/service.pp
+++ b/manifests/client/fedora/service.pp
@@ -1,0 +1,62 @@
+# Shamefully stolen from https://github.com/frimik/puppet-nfs
+# refactored a bit
+
+class nfs::client::fedora::service {
+
+  Service {
+    require => Class['nfs::client::fedora::configure']
+  }
+
+  if $nfs::client::fedora::nfs_v4 {
+    $nfs4_services_ensure = 'running'
+  } else {
+    $nfs4_services_ensure = 'stopped'
+  }
+
+  if $nfs::client::fedora::nfs_v4_kerberized {
+    $nfs4_kerberized_services_ensure = 'running'
+  } else {
+    $nfs4_kerberized_services_ensure = 'stopped'
+  }
+
+  if $nfs::client::fedora::nfs_v4_kerberized {
+    service { 'nfs-secure': 
+      provider  => 'systemd',
+      ensure    => $nfs4_kerberized_services_ensure,
+      enable    => $nfs::client::fedora::nfs_v4_kerberized,
+      hasstatus => true,
+   }
+  }
+    
+  service { 'nfs-idmap':
+    provider  => 'systemd',
+    ensure    => $nfs4_services_ensure,
+    enable    => $nfs::client::fedora::nfs_v4,
+    hasstatus => true,
+  }
+
+  
+  if !defined(Service['nfs-server']) {
+    service { 'nfs-server':
+      provider  => 'systemd',
+      name      => 'nfs-server',
+      ensure    => running,
+      enable    => true,
+      hasstatus => true,
+    }    
+  }
+
+  service {'nfs-lock':
+    ensure     => running,
+    enable     => true,
+    hasstatus  => true,
+    require    => Package["nfs-utils"]
+  }
+
+  service {"rpcbind":
+    ensure    => running,
+    enable    => true,
+    hasstatus => true,
+    require   => [Package["rpcbind"], Package["nfs-utils"]],
+  }
+}

--- a/manifests/client/rhel.pp
+++ b/manifests/client/rhel.pp
@@ -1,0 +1,20 @@
+# Shamefully stolen from https://github.com/frimik/puppet-nfs
+# refactored a bit
+
+class nfs::client::rhel (
+  $nfs_v4 = false,
+  $nfs_v4_idmap_domain = undef,
+  $nfs_v4_kerberized = false,
+  $nfs_v4_kerberos_realm = undef,
+  $rpcgssd_opts = undef,
+  $rpcsvcgssd_opts = undef,
+  $rpcidmapd_opts = undef,
+  $rpcmountd_opts = undef
+
+  
+) inherits nfs::client::rhel::params {
+
+  include nfs::client::rhel::install, 
+    nfs::client::rhel::configure, 
+    nfs::client::rhel::service
+}

--- a/manifests/client/rhel/configure.pp
+++ b/manifests/client/rhel/configure.pp
@@ -1,0 +1,38 @@
+# Shamefully stolen from https://github.com/frimik/puppet-nfs
+# refactored a bit
+
+class nfs::client::rhel::configure {
+
+  # Because RHEL /etc/sysconfig/nfs doesn't want true/false;
+  # it wants yes/no
+  if $nfs::client::rhel::nfs_v4_kerberized {
+     $nfs_v4_secure = 'yes'
+  } else {
+     $nfs_v4_secure = 'no'
+  }
+
+  concat { '/etc/idmapd.conf':
+    warn    => true,
+    mode    => '0644',
+    owner   => 'root',
+    group   => 'root',
+  }
+  concat { '/etc/sysconfig/nfs':
+    warn    => true,
+    mode    => '0644',
+    owner   => 'root',
+    group   => 'root',
+  }
+  concat::fragment { 'idmapd.conf.erb':
+    target  => '/etc/idmapd.conf',
+    order   => 01,
+    content => template('nfs/idmapd.conf.erb'),
+    notify  => Service['rpcidmapd'],
+  }
+  concat::fragment { 'rhel-sysconfig-nfs':
+    target  => '/etc/sysconfig/nfs',
+    order   => 02,
+    content => template('nfs/rhel-sysconfig-nfs.erb'),
+    notify  => Service['rpcgssd', 'rpcsvcgssd', 'rpcidmapd', 'nfs'],
+  }  
+}

--- a/manifests/client/rhel/install.pp
+++ b/manifests/client/rhel/install.pp
@@ -1,0 +1,30 @@
+# Shamefully stolen from https://github.com/frimik/puppet-nfs
+# refactored a bit
+
+class nfs::client::rhel::install {
+
+  Package {
+    before => Class['nfs::client::rhel::configure']
+  }
+  package { 'nfs-utils':
+    ensure => present,
+  }
+
+  if $nfs::client::rhel::osmajor == 6 {
+    package {'rpcbind':
+      ensure => present,
+    }
+  }
+  elsif $nfs::client::rhel::osmajor == 5 {
+    package { 'portmap':
+      ensure => present,
+    }
+  }
+
+  if $nfs::client::rhel::nfs_v4_kerberized {
+    package { ['krb5-libs', 'krb5-workstation', 'krb5-devel',]:
+      ensure => present,
+    }    
+  }
+}
+

--- a/manifests/client/rhel/params.pp
+++ b/manifests/client/rhel/params.pp
@@ -1,0 +1,13 @@
+# Shamefully stolen from https://github.com/frimik/puppet-nfs
+# refactored a bit
+
+class nfs::client::rhel::params {
+
+  if versioncmp($::operatingsystemrelease, "6.0") > 0 {
+    $osmajor = 6
+  } elsif versioncmp($::operatingsystemrelease, "5.0") > 0 {
+    $osmajor = 5
+  }
+}
+
+

--- a/manifests/client/rhel/service.pp
+++ b/manifests/client/rhel/service.pp
@@ -1,0 +1,69 @@
+# Shamefully stolen from https://github.com/frimik/puppet-nfs
+# refactored a bit
+
+class nfs::client::rhel::service {
+
+  Service {
+    require => Class['nfs::client::rhel::configure']
+  }
+
+  if $nfs::client::rhel::nfs_v4 {
+    $nfs4_services_ensure = 'running'
+  } else {
+    $nfs4_services_ensure = 'stopped'
+  }
+
+  if $nfs::client::fedora::nfs_v4_kerberized {
+    $nfs4_kerberized_services_ensure = 'running'
+  } else {
+    $nfs4_kerberized_services_ensure = 'stopped'
+  }
+
+  service { ['rpcgssd', 'rpcsvcgssd', 'rpcidmapd']:
+    ensure    => $nfs4_kerberized_services_ensure,
+    enable    => $nfs::client::rhel::nfs_v4_kerberized,
+    hasstatus => true,
+  }
+
+  if !defined(Service['nfs']) {
+    service { 'nfs':
+      ensure    => $nfs4_services_ensure,
+      enable    => $nfs::client::rhel::nfs_v4,
+      hasstatus => true,
+    }    
+  }
+
+  service {"nfslock":
+    ensure     => running,
+    enable    => true,
+    hasstatus => true,
+    require => $nfs::client::rhel::osmajor ? {
+      6 => Service["rpcbind"],
+      5 => [Package["portmap"], Package["nfs-utils"]]
+    },
+  }
+
+  service { "netfs":
+    enable  => true,
+    require => $nfs::client::rhel::osmajor ? {
+      6 => Service["nfslock"],
+      5 => [Service["portmap"], Service["nfslock"]],
+    },
+  }
+
+  if $nfs::client::rhel::osmajor == 6 {
+    service {"rpcbind":
+      ensure    => running,
+      enable    => true,
+      hasstatus => true,
+      require => [Package["rpcbind"], Package["nfs-utils"]],
+    }
+  } elsif $nfs::client::rhel::osmajor == 5 {
+    service { "portmap":
+      ensure    => running,
+      enable    => true,
+      hasstatus => true,
+      require => [Package["portmap"], Package["nfs-utils"]],
+    }
+  }
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,19 +3,31 @@ class nfs::params (
   $nfs_v4_export_root = '/export',
   $nfs_v4_export_root_clients  = "*.${::domain}(ro,fsid=root,insecure,no_subtree_check,async,root_squash)",
   $nfs_v4_mount_root  = '/srv',
-  $nfs_v4_idmap_domain = $::domain
-) {
+  $nfs_v4_idmap_domain = $::domain,
+  $nfs_v4_kerberos_realm = undef,
+  $nfs_v4_kerberized = false,
+  $rpcgssd_opts = undef,
+  $rpcsvcgssd_opts = undef,
+  $rpcidmapd_opts = undef,  
+  $rpcmountd_opts = undef,  
+  ) {
 
-  # Somehow the ::osfamliy fact doesnt exist on some oled systems
+  # Somehow the ::lsbdistid fact doesn't exist on some old systems
 
   case $::operatingsystem {
-    'centos', 'redhat', 'scientific', 'fedora': {
-      $osfamily = 'redhat'
-    } 'debian', 'Ubuntu': {
-      $osfamily = 'debian'
-    } 'windows': {
+    'centos', 'rhel', 'scientific': {
+      $lsbdistid = 'rhel'
+    }
+    'fedora': {
+      $lsbdistid = 'fedora'
+    }
+    'debian', 'Ubuntu': {
+      $lsbdistid = 'debian'
+    }
+    'windows': {
       fail('fail!11')
-    } default: {
+    }
+    default: {
       fail("OS: ${::operatingsystem} not supported")
     }
   }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -17,11 +17,36 @@
 #  and clients.
 #  Default is to use $domain fact.
 #
+# [nfs_v4_kerberized]
+#  (RHEL only) Toggles SECURE_NFS in /etc/sysconfig/nfs;
+#  enables and runs rpc.gssd and rpc.svgssd
+#
+# [nfs_v4_kerberos_realm]
+#  (RHEL only) For /etc/idmapd.conf's Local-Realms parameter.
+#
+# [rpcgssd_opts]
+#  (RHEL only) Passes options to rpc.gssd in /etc/sysconfig/nfs.
+#
+# [rpcsvcgssd_opts]
+#  (RHEL only) Passes options to rpc.svcgssd in /etc/sysconfig/nfs.
+#
+# [rpcidmapd_opts]
+#  (RHEL only) Passes options to rpc.idmapd in /etc/sysconfig/nfs.
+#
+# [rpcmountd_opts]
+#  (RHEL only) Passes options to rpc.mountd in /etc/sysconfig/nfs.
+# 
+#
 # === Examples
 #
 #
 #  class { nfs::server:
-#    nfs_v4                      => true,
+#    nfs_v4                 => true,
+#    nfs_v4_kerberos_realm  => 'EXAMPLE.COM',
+#    nfs_v4_kerberized      => true,
+#    rpcgssd_opts	    => '-v',
+#    rpcsvcgssd_opts        => '-v',
+#    rpcidmapd_opts         => '-v',
 #     nfs_v4_export_root_clients => "*.${::domain}(ro,fsid=root,insecure,no_subtree_check,async,root_squash)",
 #    # Generally parameters below have sane defaults.
 #    nfs_v4_export_root  => "/export",
@@ -38,10 +63,16 @@
 #
 
 class nfs::server (
-  $nfs_v4                       = $nfs::params::nfs_v4,
-  $nfs_v4_export_root           = $nfs::params::nfs_v4_export_root,
-  $nfs_v4_export_root_clients   = $nfs::params::nfs_v4_export_root_clients,
-  $nfs_v4_idmap_domain          = $nfs::params::domain,
+  $nfs_v4                      = $nfs::params::nfs_v4,
+  $nfs_v4_export_root          = $nfs::params::nfs_v4_export_root,
+  $nfs_v4_export_root_clients  = $nfs::params::nfs_v4_export_root_clients,
+  $nfs_v4_idmap_domain         = $nfs::params::domain,
+  $nfs_v4_kerberized           = $nfs::params::nfs_v4_kerberized,
+  $nfs_v4_kerberos_realm       = $nfs::params::nfs_v4_kerberos_realm,
+  $rpcgssd_opts                = $nfs::params::rpcgssd_opts,
+  $rpcsvcgssd_opts             = $nfs::params::rpcsvcgssd_opts,
+  $rpcidmapd_opts              = $nfs::params::rpcidmapd_opts,  
+  $rpcmountd_opts              = $nfs::params::rpcmountd_opts,
   # 
   $nfs_v4_root_export_ensure    = 'mounted',
   $nfs_v4_root_export_mount     = undef,
@@ -52,10 +83,16 @@ class nfs::server (
   $nfs_v4_root_export_tag       = undef
 ) inherits nfs::params {
 
-  class{ "nfs::server::${osfamily}":
-    nfs_v4              => $nfs_v4,
-    nfs_v4_idmap_domain => $nfs_v4_idmap_domain,
+  class{ "nfs::server::${lsbdistid}":
+    nfs_v4                 => $nfs_v4,
+    nfs_v4_idmap_domain    => $nfs_v4_idmap_domain,
+    nfs_v4_kerberized      => $nfs_v4_kerberized,
+    nfs_v4_kerberos_realm  => $nfs_v4_kerberos_realm,
+    rpcgssd_opts           => $rpcgssd_opts,
+    rpcsvcgssd_opts        => $rpcsvcgssd_opts,
+    rpcidmapd_opts         => $rpcidmapd_opts,
+    rpcmountd_opts         => $rpcmountd_opts
   }
 
-  include  nfs::server::configure
+  include nfs::server::configure
 }

--- a/manifests/server/configure.pp
+++ b/manifests/server/configure.pp
@@ -1,9 +1,8 @@
 class nfs::server::configure {
 
   concat {'/etc/exports': 
-    require => Class["nfs::server::${nfs::server::osfamily}"]
+    require => Class["nfs::server::${nfs::server::lsbdistid}"]
   }
-
 
   concat::fragment{
     'nfs_exports_header':
@@ -15,4 +14,6 @@ class nfs::server::configure {
   if $nfs::server::nfs_v4 == true {
     include nfs::server::nfs_v4::configure
   }
+  
+
 }

--- a/manifests/server/fedora.pp
+++ b/manifests/server/fedora.pp
@@ -1,0 +1,48 @@
+class nfs::server::fedora(
+  $nfs_v4 = false,
+  $nfs_v4_idmap_domain = undef,
+  $nfs_v4_kerberized = false,
+  $nfs_v4_kerberos_realm = undef,
+  $rpcgssd_opts = undef,
+  $rpcsvcgssd_opts = undef,
+  $rpcidmapd_opts = undef,
+  $rpcmountd_opts = undef,
+) {
+
+  class{ 'nfs::client::fedora':
+    nfs_v4                 => $nfs_v4,
+    nfs_v4_idmap_domain    => $nfs_v4_idmap_domain,
+    nfs_v4_kerberized      => $nfs_v4_kerberized,
+    nfs_v4_kerberos_realm  => $nfs_v4_kerberos_realm,
+    rpcgssd_opts           => $rpcgssd_opts,
+    rpcsvcgssd_opts        => $rpcsvcgssd_opts,
+    rpcidmapd_opts         => $rpcidmapd_opts,    
+    rpcmountd_opts         => $rpcmountd_opts
+  }
+
+  include nfs::server::fedora::install, nfs::server::fedora::service
+
+
+}
+
+class nfs::server::fedora::install {
+  package { 'nfs4-acl-tools':
+    ensure => installed,
+  }
+}
+
+
+class nfs::server::fedora::service {
+  if !defined(Service['nfs-server']) {
+    service { 'nfs-server':
+        provider   => 'systemd',
+        name       => 'nfs-server',
+        ensure     => running,
+        enable     => true,
+        hasrestart => true,
+        hasstatus  => true,
+        require    => Package["nfs-utils"],
+        subscribe  => [ Concat['/etc/exports'], File['/etc/idmapd.conf'], File['/etc/sysconfig/nfs'] ],
+      }
+    }
+}

--- a/manifests/server/rhel.pp
+++ b/manifests/server/rhel.pp
@@ -1,0 +1,69 @@
+class nfs::server::rhel(
+  $nfs_v4 = false,
+  $nfs_v4_idmap_domain = undef,
+  $nfs_v4_kerberized = false,
+  $nfs_v4_kerberos_realm = undef,
+  $rpcgssd_opts = undef,
+  $rpcsvcgssd_opts = undef,
+  $rpcidmapd_opts = undef,
+  $rpcmountd_opts = undef,
+) {
+
+  class{ 'nfs::client::rhel':
+    nfs_v4                 => $nfs_v4,
+    nfs_v4_idmap_domain    => $nfs_v4_idmap_domain,
+    nfs_v4_kerberized      => $nfs_v4_kerberized,
+    nfs_v4_kerberos_realm  => $nfs_v4_kerberos_realm,
+    rpcgssd_opts           => $rpcgssd_opts,
+    rpcsvcgssd_opts        => $rpcsvcgssd_opts,
+    rpcidmapd_opts         => $rpcidmapd_opts,    
+    rpcmountd_opts         => $rpcmountd_opts
+  }
+
+  include nfs::server::rhel::install, nfs::server::rhel::service
+
+
+}
+
+class nfs::server::rhel::install {
+  package { 'nfs4-acl-tools':
+    ensure => installed,
+  }
+}
+
+
+class nfs::server::rhel::service {
+
+  if $nfs::server::rhel::nfs_v4 {
+    $nfs_v4_services_ensure = 'running'
+    } else {
+    $nfs_v4_services_ensure = 'stopped'
+    }
+
+    if !defined(Service['nfs']) {
+    case $::operatingsystem {
+      centos, rhel: {
+        service {"nfs":
+          ensure     => running,
+          enable     => true,
+          hasrestart => true,
+          hasstatus  => true,
+          require    => Package["nfs-utils"],
+          subscribe  => [ Concat['/etc/exports'], File['/etc/idmapd.conf'], File['/etc/sysconfig/nfs'] ],
+        }
+      }
+      fedora: {
+        service { nfs:
+          provider   => 'systemd',
+          name       => 'nfs.service',
+          ensure     => running,
+          enable     => true,
+          hasrestart => true,
+          hasstatus  => true,
+          require    => Package["nfs-utils"],
+          subscribe  => [ Concat['/etc/exports'], File['/etc/idmapd.conf'], File['/etc/sysconfig/nfs'] ],
+        }
+      }
+    }
+   }
+}

--- a/templates/idmapd.conf.erb
+++ b/templates/idmapd.conf.erb
@@ -1,0 +1,114 @@
+[General]
+Verbosity = 1
+# The following should be set to the local NFSv4 domain name
+# The default is the host's DNS domain name.
+Domain = <%= @nfs_v4_idmap_domain %>
+
+# The following is a comma-separated list of Kerberos realm
+# names that should be considered to be equivalent to the
+# local realm, such that <user>@REALM.A can be assumed to
+# be the same user as <user>@REALM.B
+# If not specified, the default local realm is the domain name,
+# which defaults to the host's DNS domain name,
+# translated to upper-case.
+# Note that if this value is specified, the local realm name
+# must be included in the list!
+Local-Realms = <%= @nfs_v4_kerberos_realm %>
+
+[Mapping]
+
+Nobody-User = nobody
+Nobody-Group = nobody
+
+[Translation]
+
+# Translation Method is an comma-separated, ordered list of
+# translation methods that can be used.  Distributed methods
+# include "nsswitch", "umich_ldap", and "static".  Each method
+# is a dynamically loadable plugin library.
+# New methods may be defined and inserted in the list.
+# The default is "nsswitch".
+Method = nsswitch
+
+# Optional.  This is a comma-separated, ordered list of
+# translation methods to be used for translating GSS
+# authenticated names to ids.
+# If this option is omitted, the same methods as those
+# specified in "Method" are used.
+#GSS-Methods = <alternate method list for translating GSS names>
+ 
+#-------------------------------------------------------------------#
+# The following are used only for the "static" Translation Method.
+#-------------------------------------------------------------------#
+#[Static]
+
+# A "static" list of GSS-Authenticated names to
+# local user name mappings
+
+#someuser@REALM = localuser
+
+
+#-------------------------------------------------------------------#
+# The following are used only for the "umich_ldap" Translation Method.
+#-------------------------------------------------------------------#
+
+#[UMICH_SCHEMA]
+
+# server information (REQUIRED)
+#LDAP_server = ldap-server.local.domain.edu
+
+# the default search base (REQUIRED)
+#LDAP_base = dc=local,dc=domain,dc=edu
+
+#-----------------------------------------------------------#
+# The remaining options have defaults (as shown)
+# and are therefore not required.
+#-----------------------------------------------------------#
+
+# whether or not to perform canonicalization on the
+# name given as LDAP_server
+#LDAP_canonicalize_name = true
+
+# absolute search base for (people) accounts
+#LDAP_people_base = <LDAP_base>
+
+# absolute search base for groups
+#LDAP_group_base = <LDAP_base>
+
+# Set to true to enable SSL - anything else is not enabled
+#LDAP_use_ssl = false
+
+# You must specify a CA certificate location if you enable SSL
+#LDAP_ca_cert = /etc/ldapca.cert
+
+# Objectclass mapping information
+
+# Mapping for the person (account) object class
+#NFSv4_person_objectclass = NFSv4RemotePerson
+
+# Mapping for the nfsv4name attribute the person object
+#NFSv4_name_attr = NFSv4Name
+
+# Mapping for the UID number
+#NFSv4_uid_attr = UIDNumber
+
+# Mapping for the GSSAPI Principal name
+#GSS_principal_attr = GSSAuthName
+
+# Mapping for the account name attribute (usually uid)
+# The value for this attribute must match the value of 
+# the group member attribute - NFSv4_member_attr
+#NFSv4_acctname_attr = uid
+
+# Mapping for the group object class
+#NFSv4_group_objectclass = NFSv4RemoteGroup
+
+# Mapping for the GID attribute
+#NFSv4_gid_attr = GIDNumber
+
+# Mapping for the Group NFSv4 name
+#NFSv4_group_attr = NFSv4Name
+
+# Mapping for the Group member attribute (usually memberUID)
+# The value of this attribute must match the value of NFSv4_acctname_attr
+#NFSv4_member_attr = memberUID

--- a/templates/rhel-sysconfig-nfs.erb
+++ b/templates/rhel-sysconfig-nfs.erb
@@ -1,0 +1,69 @@
+#
+# Define which protocol versions mountd 
+# will advertise. The values are "no" or "yes"
+# with yes being the default
+#MOUNTD_NFS_V2="no"
+#MOUNTD_NFS_V3="no"
+#
+#
+# Path to remote quota server. See rquotad(8)
+#RQUOTAD="/usr/sbin/rpc.rquotad"
+# Port rquotad should listen on.
+#RQUOTAD_PORT=875
+# Optinal options passed to rquotad
+#RPCRQUOTADOPTS=""
+#
+#
+# Optional arguments passed to in-kernel lockd
+#LOCKDARG=
+# TCP port rpc.lockd should listen on.
+#LOCKD_TCPPORT=32803
+# UDP port rpc.lockd should listen on.
+#LOCKD_UDPPORT=32769
+#
+#
+# Optional arguments passed to rpc.nfsd. See rpc.nfsd(8)
+# Turn off v2 and v3 protocol support
+#RPCNFSDARGS="-N 2 -N 3"
+# Turn off v4 protocol support
+#RPCNFSDARGS="-N 4"
+# Number of nfs server processes to be started.
+# The default is 8. 
+#RPCNFSDCOUNT=8
+# Stop the nfsd module from being pre-loaded
+#NFSD_MODULE="noload"
+# Set V4 grace period in seconds
+#NFSD_V4_GRACE=90
+#
+#
+#
+# Optional arguments passed to rpc.mountd. See rpc.mountd(8)
+RPCMOUNTDOPTS="<%= @rpcmountd_opts %>"
+# Port rpc.mountd should listen on.
+#MOUNTD_PORT=892
+#
+#
+# Optional arguments passed to rpc.statd. See rpc.statd(8)
+#STATDARG=""
+# Port rpc.statd should listen on.
+#STATD_PORT=662
+# Outgoing port statd should used. The default is port
+# is random
+#STATD_OUTGOING_PORT=2020
+# Specify callout program 
+#STATD_HA_CALLOUT="/usr/local/bin/foo"
+#
+#
+# Optional arguments passed to rpc.idmapd. See rpc.idmapd(8)
+RPCIDMAPDARGS="<%= @rpcidmapd_opts %>"
+#
+# Set to turn on Secure NFS mounts. 
+SECURE_NFS="<%= @nfs_v4_secure %>"
+# Optional arguments passed to rpc.gssd. See rpc.gssd(8)
+RPCGSSDARGS="<%= @rpcgssd_opts %>"
+# Optional arguments passed to rpc.svcgssd. See rpc.svcgssd(8)
+RPCSVCGSSDARGS="<%= @rpcsvcgssd_opts %>"
+#
+# To enable RDMA support on the server by setting this to
+# the port the server should listen on
+#RDMA_PORT=20049 


### PR DESCRIPTION
Very nice module, thank you!  These changes allow the module to _really_ meet all our site's NFS needs.

New:
- Remove support for "redhat" in favour of "rhel/centos" and "fedora" in order to support for systemd and new NFS service names on Fedora
- Manage rpc.gssd, rpc.svcgssd on Red Hat systems (running/enabled/flags stored in /etc/sysconfig/nfs)
- Manage the Kerberos realm in /etc/idmapd.conf
- Manage /etc/idmapd.conf with ERB templates instead of augeas
