### PR TITLE
adding anchor pattern to nfs::client and dependency on nfs::client to mount call

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -44,9 +44,13 @@ class nfs::client (
   $nfs_v4_idmap_domain = $nfs::params::nfs_v4_idmap_domain
 ) inherits nfs::params {
 
+  anchor{ 'nfs::client::start': }
+  ->
   class{ "nfs::client::${osfamily}":
     nfs_v4              => $nfs_v4,
     nfs_v4_idmap_domain => $nfs_v4_idmap_domain,
   }
+  ->
+  anchor{ 'nfs::client::end': }
 
 }

--- a/manifests/client/debian.pp
+++ b/manifests/client/debian.pp
@@ -7,4 +7,13 @@ class nfs::client::debian (
     nfs::client::debian::configure,
     nfs::client::debian::service
 
+  anchor{ 'nfs::client::debian::start': }
+  ->
+  Class['nfs::client::debian::install']
+  ->
+  Class['nfs::client::debian::configure']
+  ->
+  Class['nfs::client::debian::service']
+  ->
+  anchor{ 'nfs::client::debian::end': }
 }

--- a/manifests/client/mount.pp
+++ b/manifests/client/mount.pp
@@ -75,6 +75,8 @@ define nfs::client::mount (
 
     nfs::mkdir{"${_mount}": }
 
+    Class['nfs::client']
+    ->
     mount {"shared $share by $::clientcert":
       ensure   => $ensure,
       device   => "${server}:${share}",

--- a/manifests/client/redhat.pp
+++ b/manifests/client/redhat.pp
@@ -6,9 +6,18 @@ class nfs::client::redhat (
   $nfs_v4_idmap_domain = undef
 ) inherits nfs::client::redhat::params {
 
-  include nfs::client::redhat::install, 
-    nfs::client::redhat::configure, 
+  include nfs::client::redhat::install,
+    nfs::client::redhat::configure,
     nfs::client::redhat::service
 
+  anchor{ 'nfs::client::redhat::start': }
+  ->
+  Class['nfs::client::redhat::install']
+  ->
+  Class['nfs::client::redhat::configure']
+  ->
+  Class['nfs::client::redhat::service']
+  ->
+  anchor{ 'nfs::client::redhat::end': }
 
 }

--- a/manifests/mkdir.pp
+++ b/manifests/mkdir.pp
@@ -7,10 +7,12 @@ define nfs::mkdir() {
     unless  => "test -d ${name}",
   }
 
-  file {
-    "${name}":
-      ensure  => directory,
-      require => Exec["mkdir_recurse_${name}"]
+  if !defined(File[$name]) {
+    file {
+      "${name}":
+        ensure  => directory,
+        require => Exec["mkdir_recurse_${name}"]
+    }
   }
 
 }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -42,20 +42,96 @@ class nfs::server (
   $nfs_v4_export_root           = $nfs::params::nfs_v4_export_root,
   $nfs_v4_export_root_clients   = $nfs::params::nfs_v4_export_root_clients,
   $nfs_v4_idmap_domain          = $nfs::params::domain,
-  # 
+
   $nfs_v4_root_export_ensure    = 'mounted',
   $nfs_v4_root_export_mount     = undef,
   $nfs_v4_root_export_remounts  = false,
   $nfs_v4_root_export_atboot    = false,
   $nfs_v4_root_export_options   = '_netdev',
   $nfs_v4_root_export_bindmount = undef,
-  $nfs_v4_root_export_tag       = undef
+  $nfs_v4_root_export_tag       = undef,
+  $rquotad_port                 = 875,
+  $lockd_tcpport                = 32803,
+  $lockd_udpport                = 32769,
+  $mountd_port                  = 892,
+  $statd_port                   = 662,
+  $statd_outgoing_port          = 2020,
 ) inherits nfs::params {
 
   class{ "nfs::server::${osfamily}":
     nfs_v4              => $nfs_v4,
     nfs_v4_idmap_domain => $nfs_v4_idmap_domain,
+    rquotad_port        => $rquotad_port,
+    lockd_tcpport       => $lockd_tcpport,
+    lockd_udpport       => $lockd_udpport,
+    mountd_port         => $mountd_port,
+    statd_port          => $statd_port,
+    statd_outgoing_port => $statd_outgoing_port,
   }
 
   include  nfs::server::configure
+
+  if defined(Class['firewall']) {
+    firewall { "120 nfs tcp 111":
+      proto => 'tcp',
+      state => 'NEW',
+      dport => '111',
+      action => 'accept',
+    }
+    firewall { "120 nfs udp 111":
+      proto => 'udp',
+      dport => '111',
+      action => 'accept',
+    }
+    firewall { "120 nfs tcp 2049":
+      proto => 'tcp',
+      state => 'NEW',
+      dport => '2049',
+      action => 'accept',
+    }
+    firewall { "120 nfs lockd_tcpport ${lockd_tcpport}":
+      proto  => 'tcp',
+      state  => 'NEW',
+      dport  => $lockd_tcpport,
+      action => 'accept',
+    }
+    firewall { "120 nfs lockd_udpport ${lockd_udpport}":
+      proto  => 'udp',
+      dport  => $lockd_udpport,
+      action => 'accept',
+    }
+    firewall { "120 nfs mountd_port tcp ${mountd_port}":
+      proto  => 'tcp',
+      state  => 'NEW',
+      dport  => $mountd_port,
+      action => 'accept',
+    }
+    firewall { "120 nfs mountd_port udp ${mountd_port}":
+      proto  => 'udp',
+      dport  => $mountd_port,
+      action => 'accept',
+    }
+    firewall { "120 nfs rquotad_port tcp ${rquotad_port}":
+      proto  => 'tcp',
+      state  => 'NEW',
+      dport  => $rquotad_port,
+      action => 'accept',
+    }
+    firewall { "120 nfs rquotad_port udp ${rquotad_port}":
+      proto  => 'udp',
+      dport  => $rquotad_port,
+      action => 'accept',
+    }
+    firewall { "120 nfs statd_port tcp ${statd_port}":
+      proto  => 'tcp',
+      state  => 'NEW',
+      dport  => $statd_port,
+      action => 'accept',
+    }
+    firewall { "120 nfs statd_port udp ${statd_port}":
+      proto  => 'udp',
+      dport  => $statd_port,
+      action => 'accept',
+    }
+  }
 }

--- a/manifests/server/redhat.pp
+++ b/manifests/server/redhat.pp
@@ -1,6 +1,12 @@
 class nfs::server::redhat(
-  $nfs_v4 = false,
-  $nfs_v4_idmap_domain = undef
+  $nfs_v4                       = false,
+  $nfs_v4_idmap_domain          = undef,
+  $rquotad_port                 = 875,
+  $lockd_tcpport                = 32803,
+  $lockd_udpport                = 32769,
+  $mountd_port                  = 892,
+  $statd_port                   = 662,
+  $statd_outgoing_port          = 2020,
 ) {
 
   class{ 'nfs::client::redhat':

--- a/manifests/server/redhat/service.pp
+++ b/manifests/server/redhat/service.pp
@@ -1,5 +1,20 @@
 class nfs::server::redhat::service {
 
+  if defined(Class['firewall']) {
+    augeas { 'nfs config':
+      context => '/files',
+      changes => [
+        "set etc/sysconfig/nfs/rquotad_port ${nfs::server::redhat::rquotad_port}",
+        "set etc/sysconfig/nfs/lockd_tcpport ${nfs::server::redhat::lockd_tcpport}",
+        "set etc/sysconfig/nfs/lockd_udpport ${nfs::server::redhat::lockd_udpport}",
+        "set etc/sysconfig/nfs/mountd_port ${nfs::server::redhat::mountd_port}",
+        "set etc/sysconfig/nfs/statd_port ${nfs::server::redhat::statd_port}",
+        "set etc/sysconfig/nfs/statd_outgoing_port ${nfs::server::redhat::statd_outgoing_port}",
+      ],
+      notify => Service['nfs'],
+    }
+  }
+
   if $nfs::server::redhat::nfs_v4 == true {
       service {"nfs":
         ensure     => running,


### PR DESCRIPTION
When a node is first brought up with nfs client there's a race condition between when nfs client side services are started and the mount call is made which results in the mount failing during the first run.  Added the anchor pattern to ensure all sub classes are contained by nfs::client and added a dependency to nfs::client for the mount call in nfs::client::mount
