### PR TITLE
Make sure the mounted directory is named correctly

### DIFF
--- a/manifests/client/mount.pp
+++ b/manifests/client/mount.pp
@@ -67,7 +67,7 @@ define nfs::client::mount (
 
   } else {
 
-    if $mount == undef {
+    if $mount == $title {
       $_mount = $share
     } else {
      $_mount = $mount


### PR DESCRIPTION
In cases where no $mount is specified, it is derived from context. As the $mount parameter defaults to $title, this needs to reflected in the process.
