### PR TITLE
Added ordering needed by nfs::client::mount

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -49,4 +49,8 @@ class nfs::client (
     nfs_v4_idmap_domain => $nfs_v4_idmap_domain,
   }
 
+  Class["::nfs::client::${osfamily}::install"]      ->
+  Class["::nfs::client::${osfamily}::configure"]    ->
+  Class["::nfs::client::${osfamily}"]               ->
+  Class['::nfs::client']
 }

--- a/manifests/client/mount.pp
+++ b/manifests/client/mount.pp
@@ -32,7 +32,7 @@ define nfs::client::mount (
 ) {
 
   include nfs::client
-
+  Class["nfs::client"] -> Nfs::Client::Mount["$title"]
 
   if $nfs::client::nfs_v4 == true {
 


### PR DESCRIPTION
Without this fix nfs mounts can be mounted before nfs packages get installed, which causes an error
