### PR TITLE
Removed dependency cycle

### DIFF
--- a/manifests/server/configure.pp
+++ b/manifests/server/configure.pp
@@ -1,7 +1,6 @@
 class nfs::server::configure {
 
-  concat {'/etc/exports': 
-    require => Class["nfs::server::${nfs::server::osfamily}"]
+  concat {'/etc/exports':
   }
 
 


### PR DESCRIPTION
Removed dependency cycle which failing the module under puppet 3.4: 
Error: Could not apply complete catalog: Found 1 dependency cycle:
(Exec[concat_/etc/exports] => Concat[/etc/exports] => Service[nfs-kernel-server] => Class[Nfs::Server::Debian] => Concat[/etc/exports] => Exec[concat_/etc/exports])
Try the '--graph' option and opening the resulting '.dot' file in OmniGraffle or GraphViz
