### PR TITLE
Redhat 7 Client Support

### DIFF
--- a/manifests/client/redhat/install.pp
+++ b/manifests/client/redhat/install.pp
@@ -10,7 +10,7 @@ class nfs::client::redhat::install {
     ensure => present,
   }
 
-  if $nfs::client::redhat::osmajor == 6 {
+  if $nfs::client::redhat::osmajor == 6 or $nfs::client::redhat::osmajor == 7 {
     package {'rpcbind':
       ensure => present,
     }

--- a/manifests/client/redhat/params.pp
+++ b/manifests/client/redhat/params.pp
@@ -3,7 +3,9 @@
 
 class nfs::client::redhat::params {
 
-  if versioncmp($::operatingsystemrelease, "6.0") > 0 {
+  if versioncmp($::operatingsystemrelease, "7.0") > 0 {
+    $osmajor = 7
+  } elsif versioncmp($::operatingsystemrelease, "6.0") > 0 {
     $osmajor = 6
   } elsif versioncmp($::operatingsystemrelease, "5.0") > 0 {
     $osmajor = 5

--- a/manifests/client/redhat/service.pp
+++ b/manifests/client/redhat/service.pp
@@ -8,24 +8,32 @@ class nfs::client::redhat::service {
   }
 
   service {"nfslock":
+    name => $nfs::client::redhat::osmajor ? {
+      7 => "nfs-lock",
+      6 => "nfslock",
+      5 => "nfslock"
+    },
     ensure     => running,
     enable    => true,
     hasstatus => true,
     require => $nfs::client::redhat::osmajor ? {
+      7 => Service["rpcbind"],
       6 => Service["rpcbind"],
       5 => [Package["portmap"], Package["nfs-utils"]]
     },
   }
 
-  service { "netfs":
-    enable  => true,
-    require => $nfs::client::redhat::osmajor ? {
-      6 => Service["nfslock"],
-      5 => [Service["portmap"], Service["nfslock"]],
-    },
+  if $nfs::client::redhat::osmajor == 5 or $nfs::client::redhat::osmajor == 6 {
+    service { "netfs":
+      enable  => true,
+      require => $nfs::client::redhat::osmajor ? {
+        6 => Service["nfslock"],
+        5 => [Service["portmap"], Service["nfslock"]],
+      },
+    }
   }
 
-  if $nfs::client::redhat::osmajor == 6 {
+  if $nfs::client::redhat::osmajor == 6 or $nfs::client::redhat::osmajor == 7 {
     service {"rpcbind":
       ensure    => running,
       enable    => true,

--- a/spec/classes/client_redhat_spec.rb
+++ b/spec/classes/client_redhat_spec.rb
@@ -1,5 +1,20 @@
 require 'spec_helper'
 describe 'nfs::client::redhat' do
+  let(:facts) { {:osmajor => 7 } }
+  it do
+    should contain_class('nfs::client::redhat::install')
+    should contain_class('nfs::client::redhat::configure')
+    should contain_class('nfs::client::redhat::service')
+    should contain_service('nfslock').with(
+      'ensure' => 'running'
+    )
+    should contain_package('nfs-utils')
+    should contain_class('nfs::client::redhat')
+    should contain_package('rpcbind')
+    should contain_service('rpcbind').with(
+      'ensure' => 'running'
+    )
+  end
   let(:facts) { {:osmajor => 6 } }
   it do
     should contain_class('nfs::client::redhat::install')

--- a/spec/classes/client_spec.rb
+++ b/spec/classes/client_spec.rb
@@ -13,8 +13,16 @@ describe 'nfs::client' do
     let(:facts) { {:operatingsystem => 'scientific', :osmajor => 6 } }
     it { should contain_class('nfs::client::redhat') }
   end
+  context "operatingsysten => centos v7" do
+    let(:facts) { {:operatingsystem => 'centos', :osmajor => 7 } }
+    it { should contain_class('nfs::client::redhat') }
+  end
   context "operatingsysten => centos v6" do
     let(:facts) { {:operatingsystem => 'centos', :osmajor => 6 } }
+    it { should contain_class('nfs::client::redhat') }
+  end
+  context "operatingsysten => redhat v7" do
+    let(:facts) { {:operatingsystem => 'redhat', :osmajor => 7 } }
     it { should contain_class('nfs::client::redhat') }
   end
   context "operatingsysten => redhat v6" do


### PR DESCRIPTION
Redhat 7 client support, in particualr

* The netfs service is no more.
* The netlock service is now called 'net-lock'.